### PR TITLE
Refactor the command utils package

### DIFF
--- a/cli/command/README.md
+++ b/cli/command/README.md
@@ -4,15 +4,15 @@ This module is for adding functionality to commands
 
 Say you want a function to take a name, you define the command
 ```go
-command := &cli.Command{
+someCommand := &cli.Command{
     Name: "some-command"
 }
 ```
-Now before returning if you want to attach an ability to this command
+Now before returning if you want to attach name argument parsing ability to this command
 
 ```go
-command.Name(command)
+command.Name(someCommand)
 ```
 
-This empty wrapping will attribute args[0] to name, and return an
+This empty wrapping will attribute args[0] or the name flag to `name`, and return an
 error if the name is not found

--- a/cli/command/argParsingHelpers.go
+++ b/cli/command/argParsingHelpers.go
@@ -1,0 +1,19 @@
+package command
+
+import "github.com/urfave/cli/v2"
+
+func prependArgParsingToAction(c *cli.Command, argName string, argGetter func(ctx *cli.Context) (string, error)) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		arg, err := argGetter(ctx)
+		if err != nil {
+			return err
+		}
+		ctx.Set(argName, arg)
+
+		// execute the original action at the end
+		return c.Action(ctx)
+		// ^I believe that this closure should have its own copy of c.Action before c.Action is changed, am I right?
+	}
+}
+
+// detection of trailing unparsed flags might also go here

--- a/cli/command/name.go
+++ b/cli/command/name.go
@@ -20,6 +20,8 @@ func Name(c *cli.Command) {
 	attachName(c, &flags.Name)
 }
 
+// adds the name flag to a command and prepends name parsing to the command's action
+// also adds 'name' to the args usage
 func attachName(c *cli.Command, flag cli.Flag) {
 	c.Flags = append(c.Flags, flag)
 
@@ -29,16 +31,9 @@ func attachName(c *cli.Command, flag cli.Flag) {
 		c.ArgsUsage = "name," + c.ArgsUsage
 	}
 
-	action := c.Action
-
-	c.Action = func(ctx *cli.Context) error {
-		name, err := getName(ctx)
-		if err != nil {
-			return err
-		}
-		ctx.Set("name", name)
-		return action(ctx)
-	}
+	c.Action = prependArgParsingToAction(c, "name", func(ctx *cli.Context) (string, error) {
+		return getName(ctx)
+	})
 
 }
 
@@ -50,13 +45,11 @@ func getName(c *cli.Context) (name string, err error) {
 		name = c.String("name")
 		if len(name) == 0 {
 			err = errors.New("Please provide a name")
-			return
 		}
-	} else {
-		if strings.HasPrefix(c.Args().Get(1), "-") {
-			err = errors.New("Parse arguments failed: write [arguments] after -flags")
-			return
-		}
+	} else if strings.HasPrefix(c.Args().Get(1), "-") {
+		// If the args0 is present and there is an unparsed flag following it, return an error
+		// (urfave cli does not support flags after arguments: https://github.com/urfave/cli/issues/427#issue-156378589)
+		err = errors.New("Parse arguments failed: write [arguments] after -flags")
 	}
 
 	return

--- a/cli/command/names.go
+++ b/cli/command/names.go
@@ -18,15 +18,8 @@ func attachNames(c *cli.Command, flag cli.Flag) {
 		c.ArgsUsage = "[name,...]" + c.ArgsUsage
 	}
 
-	action := c.Action
-
-	c.Action = func(ctx *cli.Context) error {
-		names, err := getName(ctx)
-		if err != nil {
-			return err
-		}
-		ctx.Set("names", names)
-		return action(ctx)
-	}
+	c.Action = prependArgParsingToAction(c, "names", func(ctx *cli.Context) (string, error) {
+		return getName(ctx)
+	})
 
 }

--- a/cli/command/universe.go
+++ b/cli/command/universe.go
@@ -1,51 +1,7 @@
 package command
 
-import (
-	"errors"
-	"log"
-	"strings"
-
-	"github.com/taubyte/dreamland/cli/common"
-	"github.com/taubyte/dreamland/cli/flags"
-	"github.com/urfave/cli/v2"
-)
+import "github.com/urfave/cli/v2"
 
 func Universe(c *cli.Command) {
-
-	c.Flags = append(c.Flags, &flags.Universe)
-
-	if len(c.ArgsUsage) == 0 {
-		log.Fatal("universe expected to be second argument")
-	}
-
-	c.ArgsUsage += ", universe"
-
-	action := c.Action
-
-	c.Action = func(ctx *cli.Context) error {
-		universe, err := getUniverse(ctx)
-		if err != nil {
-			return err
-		}
-		ctx.Set("universe", universe)
-		return action(ctx)
-	}
-}
-
-// get the universe from the flag or the secound argument
-func getUniverse(c *cli.Context) (universe string, err error) {
-	universe = c.String("universe")
-	if universe == common.DefaultUniverseName {
-		args1 := c.Args().Get(1)
-		if len(args1) != 0 {
-			universe = c.Args().Get(1)
-			if strings.HasPrefix(universe, "-") {
-				err = errors.New("Parse arguments failed: write [arguments] after -flags")
-				return
-			}
-
-		}
-	}
-
-	return
+	UniverseAtPos(c, 1)
 }

--- a/cli/command/universe0.go
+++ b/cli/command/universe0.go
@@ -1,49 +1,7 @@
 package command
 
-import (
-	"errors"
-	"strings"
-
-	"github.com/taubyte/dreamland/cli/common"
-	"github.com/taubyte/dreamland/cli/flags"
-	"github.com/urfave/cli/v2"
-)
+import "github.com/urfave/cli/v2"
 
 func Universe0(c *cli.Command) {
-	c.Flags = append(c.Flags, &flags.Universe)
-
-	if len(c.ArgsUsage) == 0 {
-		c.ArgsUsage = "universe"
-	} else {
-		c.ArgsUsage = "universe," + c.ArgsUsage
-	}
-
-	action := c.Action
-
-	c.Action = func(ctx *cli.Context) error {
-		universe, err := getUniverse0(ctx)
-		if err != nil {
-			return err
-		}
-		ctx.Set("universe", universe)
-		return action(ctx)
-	}
-}
-
-// get the universe from the flag or the first argument
-func getUniverse0(c *cli.Context) (universe string, err error) {
-	universe = c.String("universe")
-	if universe == common.DefaultUniverseName {
-		args1 := c.Args().First()
-		if len(args1) != 0 {
-			universe = c.Args().First()
-			if strings.HasPrefix(universe, "-") {
-				err = errors.New("Parse arguments failed: write [arguments] after -flags")
-				return
-			}
-
-		}
-	}
-
-	return
+	UniverseAtPos(c, 0)
 }

--- a/cli/command/universeN.go
+++ b/cli/command/universeN.go
@@ -1,0 +1,55 @@
+package command
+
+import (
+	"errors"
+	"log"
+	"strings"
+
+	"github.com/taubyte/dreamland/cli/common"
+	"github.com/taubyte/dreamland/cli/flags"
+	"github.com/urfave/cli/v2"
+)
+
+// Attaches universe argument parsing to a command.
+// `pos` is position of the universe argument, expected to be 0 or 1.
+func UniverseAtPos(c *cli.Command, pos int) {
+	c.Flags = append(c.Flags, &flags.Universe)
+
+	// Add arg name to command's ArgUsage based on arg position
+	if len(c.ArgsUsage) == 0 {
+		if pos == 1 {
+			// command has no other arguments (with a usage string) but it should
+			log.Fatal("universe expected to be second argument")
+		}
+		c.ArgsUsage = "universe"
+	} else {
+		if pos == 0 {
+			c.ArgsUsage = "universe," + c.ArgsUsage
+		} else {
+			c.ArgsUsage += ", universe"
+		}
+	}
+
+	c.Action = prependArgParsingToAction(c, "universe", func(ctx *cli.Context) (string, error) {
+		return getUniverseAtPos(ctx, pos)
+	})
+}
+
+// get the universe from the flag or the argument at position `pos`
+func getUniverseAtPos(c *cli.Context, pos int) (universe string, err error) {
+	universe = c.String("universe")
+	if universe != common.DefaultUniverseName {
+		return
+	}
+
+	universeArg := c.Args().Get(pos)
+	if len(universeArg) == 0 {
+		return
+	}
+
+	universe = universeArg
+	if strings.HasPrefix(universe, "-") {
+		err = errors.New("Parse arguments failed: write [arguments] after -flags")
+	}
+	return
+}


### PR DESCRIPTION
Reading through the `cli` folder contents I thought that the command utils were a little messy and had lot of duplicate code. I am not very experienced in Go so I am not familiar with the conventions, however, I think I made some improvements.

I thought about adding a commit with more comments for some of the individual commands but those actually have a decent amount of documentation or the function names are self explanatory.

This isn't exactly what I have been asked for but I think it demonstrates my understanding of what I studied and it might even be useful/worth merging.

- decrease amount of duplicate code
- add some comments
- update readme